### PR TITLE
Fix workflow publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Pull source
         uses: actions/checkout@v3
-      - name: build bootkit
+      - name: build showpcr
         run: |
           make
       - name: Upload artifacts

--- a/layers/stacker.yaml
+++ b/layers/stacker.yaml
@@ -61,7 +61,7 @@ build-showpcr:
        - "${{TOP_D}}/showpcr.c"
        - "${{TOP_D}}/showpcr.inf"
     binds:
-        - ${{TOP_D}}/dl -> /output
+        - ${{TOP_D}} -> /output
     run: |
         #!/bin/bash
         set -o errexit -o pipefail # -o nounset, edksetup.sh has unbound vars


### PR DESCRIPTION
Fix the publish step by adjusting the stacker.yaml bind mount path to TOP_D to match where publish step expects showpcr.efi to be located.

- Update build step name