### PR TITLE
Build and release shell.efi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,15 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: showpcr.efi
-          path: showpcr.efi
+          name: efi-applications
+          path: |
+            showpcr.efi
+            shell.efi
           if-no-files-found: error
       - name: Release bin
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          files: showpcr.efi
+          files: |
+            showpcr.efi
+            shell.efi

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,14 @@ STACKER_RELEASE ?= v1.0.0-rc4
 MYPATH = $(DL_TOOLS)
 EDK2_TARBALL = $(DL_D)/edk2.tar.gz
 SHOWPCR_EFI = $(TOP_D)/showpcr.efi
+SHELL_EFI = $(TOP_D)/shell.efi
 export PATH := $(MYPATH):$(PATH)
 
-all: $(SHOWPCR_EFI)
+all: showpcr.efi shell.efi
+
+showpcr.efi: $(SHOWPCR_EFI)
+
+shell.efi: $(SHELL_EFI)
 
 edk2.tar.gz: $(EDK2_TARBALL)
 
@@ -38,6 +43,7 @@ $(SHOWPCR_EFI): $(STACKER) showpcr.c showpcr.inf layers/stacker.yaml $(EDK2_TARB
 	"--layer-type=tar" \
 	"--stacker-file=layers/stacker.yaml"
 
+$(SHELL_EFI): $(SHOWPCR_EFI)
 
 $(STACKER):
 	@mkdir -p $(DL_TOOLS)

--- a/layers/stacker.yaml
+++ b/layers/stacker.yaml
@@ -75,3 +75,4 @@ build-showpcr:
         source edksetup.sh BaseTools
         build
         cp -v /root/edk2/Build/EmulatorX64/DEBUG_GCC5/X64/showpcr.efi /output
+        cp -v /root/edk2/Build/EmulatorX64/DEBUG_GCC5/X64/Shell.efi /output/shell.efi


### PR DESCRIPTION
The UEFI Shell application which is embedded in the edk2/ovmf firmware is useful as a stand-alone app and can be installed as an fallback boot application (EFI/BOOT/BOOTX64.EFI) and coupled with a startup.nsh script to programatically run EFI applications.

Since we already build EFI applications for showpcr, also copy out the Shell.efi application and publish it.