### PR TITLE
Insert SBAT info into EFI applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
 DOCKER_BASE ?= docker://
 UBUNTU_MIRROR ?= http://archive.ubuntu.com/ubuntu
 
+APP_VERSION = $(shell git describe --tags --always \
+        "--match=v[0-9]*.[0-9]*.[0-9]*" || echo no-git)
+ifeq ($(APP_VERSION),$(filter $(APP_VERSION), "", no-git))
+$(error "Bad value for APP_VERSION: '$(APP_VERSION)'")
+endif
+
 TOP_D := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 BUILD_D = $(TOP_D)/build
 DL_D = $(TOP_D)/dl
@@ -40,6 +46,7 @@ $(SHOWPCR_EFI): $(STACKER) showpcr.c showpcr.inf layers/stacker.yaml $(EDK2_TARB
 	"--substitute=DOCKER_BASE=$(DOCKER_BASE)" \
 	"--substitute=UBUNTU_MIRROR=$(UBUNTU_MIRROR)" \
 	"--substitute=EDK2_TARBALL=$(EDK2_TARBALL)" \
+	"--substitute=APP_VERSION=$(APP_VERSION)" \
 	"--layer-type=tar" \
 	"--stacker-file=layers/stacker.yaml"
 

--- a/layers/sbat.csv.in
+++ b/layers/sbat.csv.in
@@ -1,0 +1,2 @@
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+%%APP_NAME%%,1,Project Machine,%%APP_NAME%%,%%APP_VERSION%%,https://github.com/project-machine/showpcr

--- a/layers/stacker.yaml
+++ b/layers/stacker.yaml
@@ -60,12 +60,13 @@ build-showpcr:
     import:
        - "${{TOP_D}}/showpcr.c"
        - "${{TOP_D}}/showpcr.inf"
+       - "${{TOP_D}}/layers/sbat.csv.in"
     binds:
         - ${{TOP_D}} -> /output
     run: |
         #!/bin/bash
         set -o errexit -o pipefail # -o nounset, edksetup.sh has unbound vars
-        set +x
+        set -x
         ls -al /
 
         cd /root/edk2
@@ -74,5 +75,24 @@ build-showpcr:
         export EDK_TOOLS_PATH=/root/edk2/BaseTools
         source edksetup.sh BaseTools
         build
-        cp -v /root/edk2/Build/EmulatorX64/DEBUG_GCC5/X64/showpcr.efi /output
-        cp -v /root/edk2/Build/EmulatorX64/DEBUG_GCC5/X64/Shell.efi /output/shell.efi
+        cd /root/edk2/Build/EmulatorX64/DEBUG_GCC5/X64/
+
+        # Insert sbat section into EFI required for signing when run by shim
+        for app in showpcr.efi Shell.efi; do
+            appname=$(echo $app | tr '[:upper:]' '[:lower:]')
+            sbatf="/tmp/sbat.csv"
+            sed /stacker/sbat.csv.in \
+                -e "s,%%APP_NAME%%,$appname,g" \
+                -e "s,%%APP_VERSION%%,${{APP_VERSION}},g" \
+                > "$sbatf"
+            cat "$sbatf"
+            echo "Inserting sbat info into ${app} ..."
+            objcopy \
+            "--change-section-vma=.sbat=0x50000" \
+            "--add-section=.sbat=$sbatf" \
+            "--set-section-alignment=.sbat=512" \
+            "${app}" /output/${appname}
+
+            echo "Verifying sbat section is present..."
+            objdump --headers --section=.sbat "/output/${appname}"
+        done


### PR DESCRIPTION
Running EFI apps under SHIM requires an SBAT[1] section which provides a mechanism for handling revocation, so generate and insert an SBAT section into the apps.

Other changes:
- Add APP_VERSION to Makefile
- Fix shell execution tracing for debuggin

1. https://github.com/rhboot/shim/blob/main/SBAT.md